### PR TITLE
Return Date type instead of string (breaking change)

### DIFF
--- a/Data.cs
+++ b/Data.cs
@@ -230,7 +230,7 @@ public class Startup
                     result[i] = null;
                 else if (type == typeof(byte[]) || type == typeof(char[]))
                     result[i] = Convert.ToBase64String((byte[])result[i]);
-                else if (type == typeof(Guid) || type == typeof(DateTime))
+                else if (type == typeof(Guid))
                     result[i] = result[i].ToString();
                 else if (type == typeof(IDataReader))
                     result[i] = "<IDataReader>";


### PR DESCRIPTION
Hello,

Thanks for the great module! It turns out `edge` [returns](https://github.com/tjanczuk/edge/pull/77/files) native `Date` values and IMO that's more helpful than formatted strings.

This would be a breaking change, and I totally understand if you don't want to go through a major version bump.