### PR TITLE
Update edge-js to version 15.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -267,19 +267,12 @@
       "integrity": "sha1-vRqezblO8O1AyJRYIEZ0nlcEXlo="
     },
     "edge-js": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/edge-js/-/edge-js-11.3.0.tgz",
-      "integrity": "sha512-lXruKUMELBIhCegjRKx3d6zomeieU6n/aOK+ZV6Kg/AmUK15Gz2i0AqlHph4jBsWoRiPT1tnRvtl4IIhWuj1FQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/edge-js/-/edge-js-15.5.2.tgz",
+      "integrity": "sha512-9mR9oDcOl/VCyHOL3KlvJYEtKJ/4btqGBWnqN6hqQEalBkk1u1PKjCS2mmwgwfxmsleXy8rrccu9Gnyn3LO9LA==",
       "requires": {
         "edge-cs": "1.2.1",
-        "nan": "^2.10.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-          "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
-        }
+        "nan": "^2.14.0"
       }
     },
     "escape-string-regexp": {
@@ -641,6 +634,11 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
     "nyc": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
@@ -680,6 +678,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1472,7 +1471,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Mike Eason",
   "license": "MIT",
   "dependencies": {
-    "edge-js": "^11.3.0"
+    "edge-js": "^15.5.2"
   },
   "devDependencies": {
     "mock-require": "^2.0.2",


### PR DESCRIPTION
This should fix #11; it now supports the latest Node versions out of the box.

I'm unable to test every feature (like procedures and non-OLEDB connections), but nothing breaks in my environments (OLEDB, Node v14.17.1 on Windows 10, Node v16.4.0 on macOS 11.4 with mono 5.18.1.28; tested `execute`, `transaction`, `query`, and `scalar`). Please let me know if it works for you.